### PR TITLE
fix: make Sqids work with Scala 2.13.16

### DIFF
--- a/core/src/main/scala/sqids/Sqid.scala
+++ b/core/src/main/scala/sqids/Sqid.scala
@@ -9,6 +9,7 @@ package sqids
 import scala.annotation.tailrec
 import sqids.options.Alphabet
 import sqids.options.Blocklist
+import sqids.Utils.StringOps
 
 final case class Sqid(value: String) {
   def prefix = value.head
@@ -30,7 +31,7 @@ final case class Sqid(value: String) {
 
     val offset = _alphabet.offsetFromPrefix(prefix)
 
-    go(value.tail, _alphabet.rearrange(offset).reverse, Vector.empty)
+    go(value.tailOrEmpty, _alphabet.rearrange(offset).reverse, Vector.empty)
   }
 }
 

--- a/core/src/main/scala/sqids/Utils.scala
+++ b/core/src/main/scala/sqids/Utils.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023 Sqids
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package sqids
+
+private object Utils {
+
+  implicit class StringOps(private val s: String) extends AnyVal {
+    def tailOrEmpty: String = s.slice(1, s.length)
+  }
+
+}

--- a/core/src/main/scala/sqids/options/Alphabet.scala
+++ b/core/src/main/scala/sqids/options/Alphabet.scala
@@ -8,6 +8,7 @@ package sqids.options
 
 import scala.annotation.tailrec
 import sqids.SqidsError
+import sqids.Utils.StringOps
 
 sealed abstract case class Alphabet(value: Vector[Char]) {
   def length = value.length
@@ -16,7 +17,7 @@ sealed abstract case class Alphabet(value: Vector[Char]) {
   def separator: Char = value.head
   def removeSeparator: Alphabet = new Alphabet(value.tail) {}
   def splitAtSeparator(id: String): Either[String, (String, String)] =
-    (id.takeWhile(_ != separator), id.dropWhile(_ != separator).tail) match {
+    (id.takeWhile(_ != separator), id.dropWhile(_ != separator).tailOrEmpty) match {
       case (first, _) if first.exists(!removeSeparator.value.contains(_)) =>
         Left("First part have invalid characters")
       case res => Right(res)


### PR DESCRIPTION
Scala 2.13.16 made the following breaking change: "On the empty string, .tail and .init now throw (instead of returning the empty string)" and currently Sqids does not expect .tail to throw an exception on empty string.

This commit introduces a new extension method on String named tailOrEmpty that has the same behavior as tail before 2.13.16 and updates Sqids to use the new method instead of tail.`