### PR TITLE
chore: add entries for IntelliJ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,9 @@
 metals.sbt
 project/project
 
+.idea
+.idea_modules
+/.worksheet/
+
 target
 build


### PR DESCRIPTION
Updated `.gitignore` to include patterns for IntelliJ project files.